### PR TITLE
Feature/multi-game-support

### DIFF
--- a/AnimalCrossingGCN-Tracker/App/AnimalCrossingGCN_TrackerApp.swift
+++ b/AnimalCrossingGCN-Tracker/App/AnimalCrossingGCN_TrackerApp.swift
@@ -19,7 +19,8 @@ struct AnimalCrossingGCN_TrackerApp: App {
             Bug.self,
             Fish.self,
             Art.self
-        ])
+        ], version: Schema.Version(2, 0, 0))
+        
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
         do {

--- a/AnimalCrossingGCN-Tracker/App/AnimalCrossingGCN_TrackerApp.swift
+++ b/AnimalCrossingGCN-Tracker/App/AnimalCrossingGCN_TrackerApp.swift
@@ -10,8 +10,7 @@
 import SwiftUI
 import SwiftData
 
-@main //Main app loop here
-/*Most of the core code is in ContentView.swift */
+@main
 struct AnimalCrossingGCN_TrackerApp: App {
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
@@ -19,13 +18,18 @@ struct AnimalCrossingGCN_TrackerApp: App {
             Bug.self,
             Fish.self,
             Art.self
-        ], version: Schema.Version(2, 0, 0))
+        ])
         
-        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+        let modelConfiguration = ModelConfiguration(isStoredInMemoryOnly: true)
 
         do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
+            let container = try ModelContainer(
+                for: schema,
+                configurations: [modelConfiguration]
+            )
+            return container
         } catch {
+            print(FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.path ?? "")
             fatalError("Could not create ModelContainer: \(error)")
         }
     }()

--- a/AnimalCrossingGCN-Tracker/App/AnimalCrossingGCN_TrackerApp.swift
+++ b/AnimalCrossingGCN-Tracker/App/AnimalCrossingGCN_TrackerApp.swift
@@ -20,7 +20,7 @@ struct AnimalCrossingGCN_TrackerApp: App {
             Art.self
         ])
         
-        let modelConfiguration = ModelConfiguration(isStoredInMemoryOnly: true)
+        let modelConfiguration = ModelConfiguration(isStoredInMemoryOnly: false)
 
         do {
             let container = try ModelContainer(

--- a/AnimalCrossingGCN-Tracker/Models/Art.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Art.swift
@@ -16,7 +16,7 @@ class Art {
     var basedOn: String
     //var imageName: String // this will store the name of the image file
     var isDonated: Bool
-    var games: [ACGame] // match Fish.swift implementation exactly
+    var games: [ACGame]
 
     init(name: String, basedOn: String, isDonated: Bool = false, games: [ACGame]) {
         self.id = UUID()
@@ -27,6 +27,7 @@ class Art {
         self.games = games
     }
 }
+
 struct ArtDetailView: View {
     var art: Art
 
@@ -61,18 +62,83 @@ struct ArtDetailView: View {
 
 func getDefaultArt() -> [Art] {
     return [
-        Art(name: "Academic Painting", basedOn: "Vitruvian Man by Leonardo da Vinci", isDonated: false, games: [.ACGCN]),
-        Art(name: "Amazing Painting", basedOn: "The Night Watch by Rembrandt", isDonated: false, games: [.ACGCN]),
-        Art(name: "Basic Painting", basedOn: "The Blue Boy by Thomas Gainsborough", isDonated: false, games: [.ACGCN]),
-        Art(name: "Calm Painting", basedOn: "A Sunday Afternoon on the Island of La Grande Jatte by Georges Seurat", isDonated: false, games: [.ACGCN]),
-        Art(name: "Classic Painting", basedOn: "Washington Crossing the Delaware by Emanuel Leutze", isDonated: false, games: [.ACGCN]),
-        Art(name: "Common Painting", basedOn: "The Gleaners by Jean-François Millet", isDonated: false, games: [.ACGCN]),
-        Art(name: "Dainty Painting", basedOn: "The Star (Dancer on Stage) by Edgar Degas", isDonated: false, games: [.ACGCN]),
-        Art(name: "Famous Painting", basedOn: "Mona Lisa by Leonardo da Vinci", isDonated: false, games: [.ACGCN]),
-        Art(name: "Flowery Painting", basedOn: "Sunflowers by Vincent van Gogh", isDonated: false, games: [.ACGCN]),
-        Art(name: "Moving Painting", basedOn: "The Birth of Venus by Sandro Botticelli", isDonated: false, games: [.ACGCN]),
-        Art(name: "Quaint Painting", basedOn: "The Milkmaid by Johannes Vermeer", isDonated: false, games: [.ACGCN]),
-        Art(name: "Scary Painting", basedOn: "Otani Oniji II by Toshusai Sharaku", isDonated: false, games: [.ACGCN]),
-        Art(name: "Worthy Painting", basedOn: "Liberty Leading the People by Eugène Delacroix", isDonated: false, games: [.ACGCN])
+        Art(
+            name: "Academic Painting",
+            basedOn: "Vitruvian Man by Leonardo da Vinci",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Art(
+            name: "Amazing Painting",
+            basedOn: "The Night Watch by Rembrandt",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Art(
+            name: "Basic Painting",
+            basedOn: "The Blue Boy by Thomas Gainsborough",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Art(
+            name: "Calm Painting",
+            basedOn: "A Sunday Afternoon on the Island of La Grande Jatte by Georges Seurat",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Art(
+            name: "Classic Painting",
+            basedOn: "Washington Crossing the Delaware by Emanuel Leutze",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Art(
+            name: "Common Painting",
+            basedOn: "The Gleaners by Jean-François Millet",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Art(
+            name: "Dainty Painting",
+            basedOn: "The Star (Dancer on Stage) by Edgar Degas",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Art(
+            name: "Famous Painting",
+            basedOn: "Mona Lisa by Leonardo da Vinci",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Art(
+            name: "Flowery Painting",
+            basedOn: "Sunflowers by Vincent van Gogh",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Art(
+            name: "Moving Painting",
+            basedOn: "The Birth of Venus by Sandro Botticelli",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Art(
+            name: "Quaint Painting",
+            basedOn: "The Milkmaid by Johannes Vermeer",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Art(
+            name: "Scary Painting",
+            basedOn: "Otani Oniji II by Toshusai Sharaku",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Art(
+            name: "Worthy Painting",
+            basedOn: "Liberty Leading the People by Eugène Delacroix",
+            isDonated: false,
+            games: [.ACGCN]
+        )
     ]
 }

--- a/AnimalCrossingGCN-Tracker/Models/Art.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Art.swift
@@ -1,5 +1,8 @@
 //
 //  Art.swift
+//  AnimalCrossingGCN-Tracker
+//
+//  Created by Brock Jenkinson on 10/5/24.
 //
 
 import Foundation
@@ -8,18 +11,20 @@ import SwiftUI
 
 @Model
 class Art: ObservableObject, Identifiable {
-    var id: UUID
+    @Attribute(.unique) var id: UUID
     var name: String
-    var basedOn: String  // this field is for the real-world counterpart name and artist
+    var basedOn: String
     //var imageName: String // this will store the name of the image file
     var isDonated: Bool
+    var games: [ACGame] // New attribute for multi-game support
 
-    init(name: String, basedOn: String, isDonated: Bool = false) { //include imageName: String here once fixed
+    init(name: String, basedOn: String, isDonated: Bool = false, games: [ACGame]) {
         self.id = UUID()
         self.name = name
         self.basedOn = basedOn
-      //  self.imageName = imageName
+        //self.imageName = imageName
         self.isDonated = isDonated
+        self.games = games
     }
 }
 
@@ -28,12 +33,11 @@ struct ArtDetailView: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-
             Text("Based on: \(art.basedOn)")
                 .font(.subheadline)
                 .foregroundColor(.primary)
 
-            // I will uncomment this once we have images in the assets folder, just putting in the framework for now
+            // I will uncomment this once we have images in the assets folder
             // Image(art.imageName)
             //     .resizable()
             //     .scaledToFit()
@@ -56,21 +60,20 @@ struct ArtDetailView: View {
     }
 }
 
-// This function returns the array of art pieces
 func getDefaultArt() -> [Art] {
     return [
-        Art(name: "Academic Painting", basedOn: "Vitruvian Man by Leonardo da Vinci", isDonated: false),
-        Art(name: "Amazing Painting", basedOn: "The Night Watch by Rembrandt", isDonated: false),
-        Art(name: "Basic Painting", basedOn: "The Blue Boy by Thomas Gainsborough", isDonated: false),
-        Art(name: "Calm Painting", basedOn: "A Sunday Afternoon on the Island of La Grande Jatte by Georges Seurat", isDonated: false),
-        Art(name: "Classic Painting", basedOn: "Washington Crossing the Delaware by Emanuel Leutze", isDonated: false),
-        Art(name: "Common Painting", basedOn: "The Gleaners by Jean-François Millet", isDonated: false),
-        Art(name: "Dainty Painting", basedOn: "The Star (Dancer on Stage) by Edgar Degas", isDonated: false),
-        Art(name: "Famous Painting", basedOn: "Mona Lisa by Leonardo da Vinci", isDonated: false),
-        Art(name: "Flowery Painting", basedOn: "Sunflowers by Vincent van Gogh", isDonated: false),
-        Art(name: "Moving Painting", basedOn: "The Birth of Venus by Sandro Botticelli", isDonated: false),
-        Art(name: "Quaint Painting", basedOn: "The Milkmaid by Johannes Vermeer", isDonated: false),
-        Art(name: "Scary Painting", basedOn: "Otani Oniji II by Toshusai Sharaku", isDonated: false),
-        Art(name: "Worthy Painting", basedOn: "Liberty Leading the People by Eugène Delacroix", isDonated: false)
+        Art(name: "Academic Painting", basedOn: "Vitruvian Man by Leonardo da Vinci", isDonated: false, games: [.ACGCN]),
+        Art(name: "Amazing Painting", basedOn: "The Night Watch by Rembrandt", isDonated: false, games: [.ACGCN]),
+        Art(name: "Basic Painting", basedOn: "The Blue Boy by Thomas Gainsborough", isDonated: false, games: [.ACGCN]),
+        Art(name: "Calm Painting", basedOn: "A Sunday Afternoon on the Island of La Grande Jatte by Georges Seurat", isDonated: false, games: [.ACGCN]),
+        Art(name: "Classic Painting", basedOn: "Washington Crossing the Delaware by Emanuel Leutze", isDonated: false, games: [.ACGCN]),
+        Art(name: "Common Painting", basedOn: "The Gleaners by Jean-François Millet", isDonated: false, games: [.ACGCN]),
+        Art(name: "Dainty Painting", basedOn: "The Star (Dancer on Stage) by Edgar Degas", isDonated: false, games: [.ACGCN]),
+        Art(name: "Famous Painting", basedOn: "Mona Lisa by Leonardo da Vinci", isDonated: false, games: [.ACGCN]),
+        Art(name: "Flowery Painting", basedOn: "Sunflowers by Vincent van Gogh", isDonated: false, games: [.ACGCN]),
+        Art(name: "Moving Painting", basedOn: "The Birth of Venus by Sandro Botticelli", isDonated: false, games: [.ACGCN]),
+        Art(name: "Quaint Painting", basedOn: "The Milkmaid by Johannes Vermeer", isDonated: false, games: [.ACGCN]),
+        Art(name: "Scary Painting", basedOn: "Otani Oniji II by Toshusai Sharaku", isDonated: false, games: [.ACGCN]),
+        Art(name: "Worthy Painting", basedOn: "Liberty Leading the People by Eugène Delacroix", isDonated: false, games: [.ACGCN])
     ]
 }

--- a/AnimalCrossingGCN-Tracker/Models/Art.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Art.swift
@@ -10,13 +10,13 @@ import SwiftData
 import SwiftUI
 
 @Model
-class Art: ObservableObject, Identifiable {
+class Art {
     @Attribute(.unique) var id: UUID
     var name: String
     var basedOn: String
     //var imageName: String // this will store the name of the image file
     var isDonated: Bool
-    var games: [ACGame] // New attribute for multi-game support
+    var games: [ACGame] // match Fish.swift implementation exactly
 
     init(name: String, basedOn: String, isDonated: Bool = false, games: [ACGame]) {
         self.id = UUID()
@@ -27,7 +27,6 @@ class Art: ObservableObject, Identifiable {
         self.games = games
     }
 }
-
 struct ArtDetailView: View {
     var art: Art
 

--- a/AnimalCrossingGCN-Tracker/Models/Art.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Art.swift
@@ -16,7 +16,17 @@ class Art {
     var basedOn: String
     //var imageName: String // this will store the name of the image file
     var isDonated: Bool
-    var games: [ACGame]
+    var gameRawValues: [String]
+    
+    // Computed property to access ACGame enums
+    var games: [ACGame] {
+        get {
+            gameRawValues.compactMap { ACGame(rawValue: $0) }
+        }
+        set {
+            gameRawValues = newValue.map { $0.rawValue }
+        }
+    }
 
     init(name: String, basedOn: String, isDonated: Bool = false, games: [ACGame]) {
         self.id = UUID()
@@ -24,7 +34,7 @@ class Art {
         self.basedOn = basedOn
         //self.imageName = imageName
         self.isDonated = isDonated
-        self.games = games
+        self.gameRawValues = games.map { $0.rawValue }
     }
 }
 

--- a/AnimalCrossingGCN-Tracker/Models/Bug.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Bug.swift
@@ -9,12 +9,12 @@ import SwiftData
 import SwiftUI
 
 @Model
-class Bug: ObservableObject, Identifiable {
+class Bug {
     @Attribute(.unique) var id: UUID
     var name: String
     var season: String?
     var isDonated: Bool
-    var games: [ACGame] // New attribute for multi-game support
+    var games: [ACGame]
 
     init(name: String, season: String, isDonated: Bool = false, games: [ACGame]) {
         self.id = UUID()
@@ -50,45 +50,245 @@ struct BugDetailView: View {
 
 func getDefaultBugs() -> [Bug] {
     return [
-        Bug(name: "Common Butterfly", season: "March - October", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Clouded Yellow Butterfly", season: "March - October", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Tiger Swallowtail Butterfly", season: "April - September", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Purple Butterfly", season: "June - July", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Brown Cicada", season: "July - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Robust Cicada", season: "July - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Walker Cicada", season: "July - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Evening Cicada", season: "July - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Red Dragonfly", season: "September - October", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Common Dragonfly", season: "May - July", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Darner Dragonfly", season: "June - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Banded Dragonfly", season: "July - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Cricket", season: "September - November", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Grasshopper", season: "July - September", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Pine Cricket", season: "September - October", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Bell Cricket", season: "September - October", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Ladybug", season: "March - June, October", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Seven-spotted Ladybug", season: "March - June, August - October", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Mantis", season: "August - October", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Long Locust", season: "August - October", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Migratory Locust", season: "September - November", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Cockroach", season: "January - December", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Bee", season: "January - December", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Firefly", season: "June", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Drone Beetle", season: "July - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Longhorn Beetle", season: "June - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Jewel Beetle", season: "July - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Dynastid Beetle", season: "July - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Flat Stag Beetle", season: "June - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Saw Stag Beetle", season: "July - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Mountain Stag Beetle", season: "July - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Giant Beetle", season: "July - August", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Pondskater", season: "June - September", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Ant", season: "January - December", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Pill Bug", season: "January - December", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Mosquito", season: "June - September", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Mole Cricket", season: "January - May, November - December", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Spider", season: "April - September", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Snail", season: "April - September", isDonated: false, games: [.ACGCN]),
-        Bug(name: "Bagworm", season: "January - March, October - December", isDonated: false, games: [.ACGCN])
+        Bug(
+            name: "Common Butterfly",
+            season: "March - October",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Clouded Yellow Butterfly",
+            season: "March - October",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Tiger Swallowtail Butterfly",
+            season: "April - September",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Purple Butterfly",
+            season: "June - July",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Brown Cicada",
+            season: "July - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Robust Cicada",
+            season: "July - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Walker Cicada",
+            season: "July - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Evening Cicada",
+            season: "July - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Red Dragonfly",
+            season: "September - October",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Common Dragonfly",
+            season: "May - July",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Darner Dragonfly",
+            season: "June - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Banded Dragonfly",
+            season: "July - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Cricket",
+            season: "September - November",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Grasshopper",
+            season: "July - September",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Pine Cricket",
+            season: "September - October",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Bell Cricket",
+            season: "September - October",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Ladybug",
+            season: "March - June, October",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Seven-spotted Ladybug",
+            season: "March - June, August - October",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Mantis",
+            season: "August - October",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Long Locust",
+            season: "August - October",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Migratory Locust",
+            season: "September - November",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Cockroach",
+            season: "January - December",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Bee",
+            season: "January - December",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Firefly",
+            season: "June",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Drone Beetle",
+            season: "July - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Longhorn Beetle",
+            season: "June - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Jewel Beetle",
+            season: "July - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Dynastid Beetle",
+            season: "July - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Flat Stag Beetle",
+            season: "June - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Saw Stag Beetle",
+            season: "July - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Mountain Stag Beetle",
+            season: "July - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Giant Beetle",
+            season: "July - August",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Pondskater",
+            season: "June - September",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Ant",
+            season: "January - December",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Pill Bug",
+            season: "January - December",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Mosquito",
+            season: "June - September",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Mole Cricket",
+            season: "January - May, November - December",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Spider",
+            season: "April - September",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Snail",
+            season: "April - September",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Bug(
+            name: "Bagworm",
+            season: "January - March, October - December",
+            isDonated: false,
+            games: [.ACGCN]
+        )
     ]
 }

--- a/AnimalCrossingGCN-Tracker/Models/Bug.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Bug.swift
@@ -14,14 +14,24 @@ class Bug {
     var name: String
     var season: String?
     var isDonated: Bool
-    var games: [ACGame]
+    var gameRawValues: [String]
+    
+    // Computed property to access ACGame enums
+    var games: [ACGame] {
+        get {
+            gameRawValues.compactMap { ACGame(rawValue: $0) }
+        }
+        set {
+            gameRawValues = newValue.map { $0.rawValue }
+        }
+    }
 
     init(name: String, season: String, isDonated: Bool = false, games: [ACGame]) {
         self.id = UUID()
         self.name = name
         self.season = season
         self.isDonated = isDonated
-        self.games = games
+        self.gameRawValues = games.map { $0.rawValue }
     }
 }
 

--- a/AnimalCrossingGCN-Tracker/Models/Bug.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Bug.swift
@@ -8,30 +8,29 @@ import Foundation
 import SwiftData
 import SwiftUI
 
-// This function returns the default array of bugs
-
 @Model
-class Bug: ObservableObject, Identifiable { //define the Bug class
-    var id: UUID //define the id attribute, using UUID because it is unique!
+class Bug: ObservableObject, Identifiable {
+    @Attribute(.unique) var id: UUID
     var name: String
-    var season: String? //define the season attribute, using optional String because it may not be known (though it should be)
+    var season: String?
     var isDonated: Bool
+    var games: [ACGame] // New attribute for multi-game support
 
-    init(name: String, season: String, isDonated: Bool = false) { //initialize the Bug class
-        self.id = UUID()//set the id to a new UUID
-        self.name = name //set the name to the name passed in
-        self.season = season //set the season to the season passed in
-        self.isDonated = isDonated //set the isDonated to the isDonated passed in
+    init(name: String, season: String, isDonated: Bool = false, games: [ACGame]) {
+        self.id = UUID()
+        self.name = name
+        self.season = season
+        self.isDonated = isDonated
+        self.games = games
     }
 }
 
-struct BugDetailView: View { //need to maybe make a seperate function for iphones.
+struct BugDetailView: View {
     var bug: Bug
 
     var body: some View {
-        VStack(alignment: .leading) { //create a vertical stack with leading alignment
-            // Safely unwrap the optional season value
-            Text("Season: \(bug.season ?? "N/A")")  //display the season of the bug, "??" means if the season is nil, it will  display "N/A"
+        VStack(alignment: .leading) {
+            Text("Season: \(bug.season ?? "N/A")")
                 .font(.title2)
             
             Toggle("Donated", isOn: Binding(
@@ -51,45 +50,45 @@ struct BugDetailView: View { //need to maybe make a seperate function for iphone
 
 func getDefaultBugs() -> [Bug] {
     return [
-        Bug(name: "Common Butterfly", season: "March - October", isDonated: false),
-        Bug(name: "Clouded Yellow Butterfly", season: "March - October", isDonated: false),
-        Bug(name: "Tiger Swallowtail Butterfly", season: "April - September", isDonated: false),
-        Bug(name: "Purple Butterfly", season: "June - July", isDonated: false),
-        Bug(name: "Brown Cicada", season: "July - August", isDonated: false),
-        Bug(name: "Robust Cicada", season: "July - August", isDonated: false),
-        Bug(name: "Walker Cicada", season: "July - August", isDonated: false),
-        Bug(name: "Evening Cicada", season: "July - August", isDonated: false),
-        Bug(name: "Red Dragonfly", season: "September - October", isDonated: false),
-        Bug(name: "Common Dragonfly", season: "May - July", isDonated: false),
-        Bug(name: "Darner Dragonfly", season: "June - August", isDonated: false),
-        Bug(name: "Banded Dragonfly", season: "July - August", isDonated: false),
-        Bug(name: "Cricket", season: "September - November", isDonated: false),
-        Bug(name: "Grasshopper", season: "July - September", isDonated: false),
-        Bug(name: "Pine Cricket", season: "September - October", isDonated: false),
-        Bug(name: "Bell Cricket", season: "September - October", isDonated: false),
-        Bug(name: "Ladybug", season: "March - June, October", isDonated: false),
-        Bug(name: "Seven-spotted Ladybug", season: "March - June, August - October", isDonated: false),
-        Bug(name: "Mantis", season: "August - October", isDonated: false),
-        Bug(name: "Long Locust", season: "August - October", isDonated: false),
-        Bug(name: "Migratory Locust", season: "September - November", isDonated: false),
-        Bug(name: "Cockroach", season: "January - December", isDonated: false),
-        Bug(name: "Bee", season: "January - December", isDonated: false),
-        Bug(name: "Firefly", season: "June", isDonated: false),
-        Bug(name: "Drone Beetle", season: "July - August", isDonated: false),
-        Bug(name: "Longhorn Beetle", season: "June - August", isDonated: false),
-        Bug(name: "Jewel Beetle", season: "July - August", isDonated: false),
-        Bug(name: "Dynastid Beetle", season: "July - August", isDonated: false),
-        Bug(name: "Flat Stag Beetle", season: "June - August", isDonated: false),
-        Bug(name: "Saw Stag Beetle", season: "July - August", isDonated: false),
-        Bug(name: "Mountain Stag Beetle", season: "July - August", isDonated: false),
-        Bug(name: "Giant Beetle", season: "July - August", isDonated: false),
-        Bug(name: "Pondskater", season: "June - September", isDonated: false),
-        Bug(name: "Ant", season: "January - December", isDonated: false),
-        Bug(name: "Pill Bug", season: "January - December", isDonated: false),
-        Bug(name: "Mosquito", season: "June - September", isDonated: false),
-        Bug(name: "Mole Cricket", season: "January - May, November - December", isDonated: false),
-        Bug(name: "Spider", season: "April - September", isDonated: false),
-        Bug(name: "Snail", season: "April - September", isDonated: false),
-        Bug(name: "Bagworm", season: "January - March, October - December", isDonated: false)
+        Bug(name: "Common Butterfly", season: "March - October", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Clouded Yellow Butterfly", season: "March - October", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Tiger Swallowtail Butterfly", season: "April - September", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Purple Butterfly", season: "June - July", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Brown Cicada", season: "July - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Robust Cicada", season: "July - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Walker Cicada", season: "July - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Evening Cicada", season: "July - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Red Dragonfly", season: "September - October", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Common Dragonfly", season: "May - July", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Darner Dragonfly", season: "June - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Banded Dragonfly", season: "July - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Cricket", season: "September - November", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Grasshopper", season: "July - September", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Pine Cricket", season: "September - October", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Bell Cricket", season: "September - October", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Ladybug", season: "March - June, October", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Seven-spotted Ladybug", season: "March - June, August - October", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Mantis", season: "August - October", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Long Locust", season: "August - October", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Migratory Locust", season: "September - November", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Cockroach", season: "January - December", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Bee", season: "January - December", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Firefly", season: "June", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Drone Beetle", season: "July - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Longhorn Beetle", season: "June - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Jewel Beetle", season: "July - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Dynastid Beetle", season: "July - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Flat Stag Beetle", season: "June - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Saw Stag Beetle", season: "July - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Mountain Stag Beetle", season: "July - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Giant Beetle", season: "July - August", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Pondskater", season: "June - September", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Ant", season: "January - December", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Pill Bug", season: "January - December", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Mosquito", season: "June - September", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Mole Cricket", season: "January - May, November - December", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Spider", season: "April - September", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Snail", season: "April - September", isDonated: false, games: [.ACGCN]),
+        Bug(name: "Bagworm", season: "January - March, October - December", isDonated: false, games: [.ACGCN])
     ]
 }

--- a/AnimalCrossingGCN-Tracker/Models/Fish.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Fish.swift
@@ -15,15 +15,25 @@ class Fish {
     var season: String
     var location: String
     var isDonated: Bool
-    var games: [ACGame] //new attribute to the model, this will be used to store the games that the fish is in
+    var gameRawValues: [String]
+    
+    // Computed property to access ACGame enums
+    var games: [ACGame] {
+        get {
+            gameRawValues.compactMap { ACGame(rawValue: $0) }
+        }
+        set {
+            gameRawValues = newValue.map { $0.rawValue }
+        }
+    }
 
-init(name: String, season: String, location: String, isDonated: Bool = false, games: [ACGame]) { //init for the model, this is used when creating a new instance of the model
+    init(name: String, season: String, location: String, isDonated: Bool = false, games: [ACGame]) {
         self.id = UUID()
         self.name = name
         self.season = season
         self.location = location
         self.isDonated = isDonated
-        self.games = games 
+        self.gameRawValues = games.map { $0.rawValue }
     }
 }
 
@@ -32,14 +42,11 @@ struct FishDetailView: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-        
-            
             Text("Season: \(Fish.season)")
                 .font(.title2)
             
             Text("Location: \(Fish.location)")
                 
-            
             Toggle("Donated", isOn: Binding(
                 get: { Fish.isDonated },
                 set: { newValue in

--- a/AnimalCrossingGCN-Tracker/Models/Fish.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Fish.swift
@@ -28,8 +28,11 @@ class Fish {
 }
 // Helper enum for type safety when adding games
 enum ACGame: String {
-    case gameCube = "ACGCN"
-    case newHorizons = "ACNH"
+    case gameCube = "ACGCN" //Animal Crossing on the GameCube (Population Growing)
+    case wildWorld = "ACWW" //Animal Crossing Wild World
+    case cityFolk = "ACCF" //Animal Crossing City Folk
+    case newLeaf = "ACNL" //Animal Crossing New Leaf
+    case newHorizons = "ACNH" //Animal Crossing New Horizons
 }
 
 struct FishDetailView: View {

--- a/AnimalCrossingGCN-Tracker/Models/Fish.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Fish.swift
@@ -65,45 +65,285 @@ struct FishDetailView: View {
 
 func getDefaultFish() -> [Fish] {
     return [
-        Fish(name: "Sea Bass", season: "All", location: "Sea", isDonated: false),
-        Fish(name: "Brook Trout", season: "All", location: "Lake", isDonated: false),
-        Fish(name: "Crucian Carp", season: "All", location: "River", isDonated: false),
-        Fish(name: "Carp", season: "All", location: "River", isDonated: false),
-        Fish(name: "Koi", season: "All", location: "River", isDonated: false),
-        Fish(name: "Barbel Steed", season: "All", location: "River", isDonated: false),
-        Fish(name: "Dace", season: "All", location: "River", isDonated: false),
-        Fish(name: "Catfish", season: "June - September", location: "River", isDonated: false),
-        Fish(name: "Giant Catfish", season: "July - August", location: "Lake", isDonated: false),
-        Fish(name: "Pale Chub", season: "All", location: "River", isDonated: false),
-        Fish(name: "Bitterling", season: "November - February", location: "River", isDonated: false),
-        Fish(name: "Loach", season: "March - May", location: "River", isDonated: false),
-        Fish(name: "Bluegill", season: "All", location: "River", isDonated: false),
-        Fish(name: "Small Bass", season: "All", location: "River", isDonated: false),
-        Fish(name: "Bass", season: "All", location: "River", isDonated: false),
-        Fish(name: "Large Bass", season: "All", location: "River", isDonated: false),
-        Fish(name: "Giant Snakehead", season: "July - August", location: "Lake", isDonated: false),
-        Fish(name: "Eel", season: "September - October", location: "River", isDonated: false),
-        Fish(name: "Freshwater Goby", season: "All", location: "River", isDonated: false),
-        Fish(name: "Pond Smelt", season: "December - February", location: "River", isDonated: false),
-        Fish(name: "Sweetfish", season: "July - September", location: "River", isDonated: false),
-        Fish(name: "Cherry Salmon", season: "March - June, September - November", location: "River", isDonated: false),
-        Fish(name: "Rainbow Trout", season: "March - June", location: "River", isDonated: false),
-        Fish(name: "Stringfish", season: "December - February", location: "River", isDonated: false),
-        Fish(name: "Salmon", season: "September", location: "River (mouth)", isDonated: false),
-        Fish(name: "Goldfish", season: "All", location: "River", isDonated: false),
-        Fish(name: "Pop-eyed Goldfish", season: "All", location: "River", isDonated: false),
-        Fish(name: "Guppy", season: "April - November", location: "River", isDonated: false),
-        Fish(name: "Angelfish", season: "May - October", location: "River", isDonated: false),
-        Fish(name: "Piranha", season: "June - September", location: "River", isDonated: false),
-        Fish(name: "Arowana", season: "June - September", location: "River", isDonated: false),
-        Fish(name: "Coelacanth", season: "All (raining)", location: "Sea", isDonated: false),
-        Fish(name: "Crawfish", season: "April - September", location: "Pond", isDonated: false),
-        Fish(name: "Frog", season: "May - August", location: "Pond", isDonated: false),
-        Fish(name: "Killifish", season: "April - August", location: "River", isDonated: false),
-        Fish(name: "Jellyfish", season: "August", location: "Sea", isDonated: false),
-        Fish(name: "Red Snapper", season: "All", location: "Sea", isDonated: false),
-        Fish(name: "Barred Knifejaw", season: "March - November", location: "Sea", isDonated: false),
-        Fish(name: "Arapaima", season: "July - September", location: "River", isDonated: false),
-        Fish(name: "Squid", season: "December - August", location: "Sea", isDonated: false)
+        Fish(
+            name: "Sea Bass",
+            season: "All",
+            location: "Sea",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Brook Trout",
+            season: "All",
+            location: "Lake",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Crucian Carp",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Carp",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Koi",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Barbel Steed",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Dace",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Catfish",
+            season: "June - September",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Giant Catfish",
+            season: "July - August",
+            location: "Lake",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Pale Chub",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Bitterling",
+            season: "November - February",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Loach",
+            season: "March - May",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Bluegill",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Small Bass",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Bass",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Large Bass",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Giant Snakehead",
+            season: "July - August",
+            location: "Lake",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Eel",
+            season: "September - October",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Freshwater Goby",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Pond Smelt",
+            season: "December - February",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Sweetfish",
+            season: "July - September",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Cherry Salmon",
+            season: "March - June, September - November",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Rainbow Trout",
+            season: "March - June",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Stringfish",
+            season: "December - February",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Salmon",
+            season: "September",
+            location: "River (mouth)",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Goldfish",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Pop-eyed Goldfish",
+            season: "All",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Guppy",
+            season: "April - November",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Angelfish",
+            season: "May - October",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Piranha",
+            season: "June - September",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Arowana",
+            season: "June - September",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Coelacanth",
+            season: "All (raining)",
+            location: "Sea",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Crawfish",
+            season: "April - September",
+            location: "Pond",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Frog",
+            season: "May - August",
+            location: "Pond",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Killifish",
+            season: "April - August",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Jellyfish",
+            season: "August",
+            location: "Sea",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Red Snapper",
+            season: "All",
+            location: "Sea",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Barred Knifejaw",
+            season: "March - November",
+            location: "Sea",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Arapaima",
+            season: "July - September",
+            location: "River",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        ),
+        Fish(
+            name: "Squid",
+            season: "December - August",
+            location: "Sea",
+            isDonated: false,
+            games: [ACGame.gameCube.rawValue]
+        )
     ]
 }

--- a/AnimalCrossingGCN-Tracker/Models/Fish.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Fish.swift
@@ -15,7 +15,7 @@ class Fish {
     var season: String
     var location: String
     var isDonated: Bool
-    var games: [String] //new attribute to the model, this will be used to store the games that the fish is in
+    var games: [ACGame] //new attribute to the model, this will be used to store the games that the fish is in
 
 init(name: String, season: String, location: String, isDonated: Bool = false, games: [String]) { //init for the model, this is used when creating a new instance of the model
         self.id = UUID()
@@ -25,14 +25,6 @@ init(name: String, season: String, location: String, isDonated: Bool = false, ga
         self.isDonated = isDonated
         self.games = games 
     }
-}
-// Helper enum for type safety when adding games
-enum ACGame: String {
-    case gameCube = "ACGCN" //Animal Crossing on the GameCube (Population Growing)
-    case wildWorld = "ACWW" //Animal Crossing Wild World
-    case cityFolk = "ACCF" //Animal Crossing City Folk
-    case newLeaf = "ACNL" //Animal Crossing New Leaf
-    case newHorizons = "ACNH" //Animal Crossing New Horizons
 }
 
 struct FishDetailView: View {

--- a/AnimalCrossingGCN-Tracker/Models/Fish.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Fish.swift
@@ -17,7 +17,7 @@ class Fish {
     var isDonated: Bool
     var games: [ACGame] //new attribute to the model, this will be used to store the games that the fish is in
 
-init(name: String, season: String, location: String, isDonated: Bool = false, games: [String]) { //init for the model, this is used when creating a new instance of the model
+init(name: String, season: String, location: String, isDonated: Bool = false, games: [ACGame]) { //init for the model, this is used when creating a new instance of the model
         self.id = UUID()
         self.name = name
         self.season = season

--- a/AnimalCrossingGCN-Tracker/Models/Fish.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Fish.swift
@@ -17,7 +17,7 @@ class Fish {
     var isDonated: Bool
     var games: [String] //new attribute to the model, this will be used to store the games that the fish is in
 
-    init(name: String, season: String, location: String, isDonated: Bool = false) { //init for the model, this is used when creating a new instance of the model
+init(name: String, season: String, location: String, isDonated: Bool = false, games: [String]) { //init for the model, this is used when creating a new instance of the model
         self.id = UUID()
         self.name = name
         self.season = season

--- a/AnimalCrossingGCN-Tracker/Models/Fish.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Fish.swift
@@ -15,14 +15,21 @@ class Fish {
     var season: String
     var location: String
     var isDonated: Bool
+    var games: [String] //new attribute to the model, this will be used to store the games that the fish is in
 
-    init(name: String, season: String, location: String, isDonated: Bool = false) {
+    init(name: String, season: String, location: String, isDonated: Bool = false) { //init for the model, this is used when creating a new instance of the model
         self.id = UUID()
         self.name = name
         self.season = season
         self.location = location
         self.isDonated = isDonated
+        self.games = games 
     }
+}
+// Helper enum for type safety when adding games
+enum ACGame: String {
+    case gameCube = "ACGCN"
+    case newHorizons = "ACNH"
 }
 
 struct FishDetailView: View {

--- a/AnimalCrossingGCN-Tracker/Models/Fish.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Fish.swift
@@ -62,280 +62,280 @@ func getDefaultFish() -> [Fish] {
             season: "All",
             location: "Sea",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Brook Trout",
             season: "All",
             location: "Lake",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Crucian Carp",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Carp",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Koi",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Barbel Steed",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Dace",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Catfish",
             season: "June - September",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Giant Catfish",
             season: "July - August",
             location: "Lake",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Pale Chub",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Bitterling",
             season: "November - February",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Loach",
             season: "March - May",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Bluegill",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Small Bass",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Bass",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Large Bass",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Giant Snakehead",
             season: "July - August",
             location: "Lake",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Eel",
             season: "September - October",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Freshwater Goby",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Pond Smelt",
             season: "December - February",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Sweetfish",
             season: "July - September",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Cherry Salmon",
             season: "March - June, September - November",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Rainbow Trout",
             season: "March - June",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Stringfish",
             season: "December - February",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Salmon",
             season: "September",
             location: "River (mouth)",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Goldfish",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Pop-eyed Goldfish",
             season: "All",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Guppy",
             season: "April - November",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Angelfish",
             season: "May - October",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Piranha",
             season: "June - September",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Arowana",
             season: "June - September",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Coelacanth",
             season: "All (raining)",
             location: "Sea",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Crawfish",
             season: "April - September",
             location: "Pond",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Frog",
             season: "May - August",
             location: "Pond",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Killifish",
             season: "April - August",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Jellyfish",
             season: "August",
             location: "Sea",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Red Snapper",
             season: "All",
             location: "Sea",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Barred Knifejaw",
             season: "March - November",
             location: "Sea",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Arapaima",
             season: "July - September",
             location: "River",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         ),
         Fish(
             name: "Squid",
             season: "December - August",
             location: "Sea",
             isDonated: false,
-            games: [ACGame.gameCube.rawValue]
+            games: [.ACGCN]
         )
     ]
 }

--- a/AnimalCrossingGCN-Tracker/Models/Fossil.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Fossil.swift
@@ -49,30 +49,150 @@ struct FossilDetailView: View {
 
 func getDefaultFossils() -> [Fossil] {
     return [
-        Fossil(name: "T. Rex", part: "Skull", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "T. Rex", part: "Torso", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "T. Rex", part: "Tail", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Triceratops", part: "Skull", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Triceratops", part: "Torso", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Triceratops", part: "Tail", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Stegosaurus", part: "Skull", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Stegosaurus", part: "Torso", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Stegosaurus", part: "Tail", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Pteranodon", part: "Skull", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Pteranodon", part: "Left Wing", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Pteranodon", part: "Right Wing", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Plesiosaurus", part: "Skull", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Plesiosaurus", part: "Neck", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Plesiosaurus", part: "Torso", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Apatosaurus", part: "Skull", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Apatosaurus", part: "Torso", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Apatosaurus", part: "Tail", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Mammoth", part: "Skull", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Mammoth", part: "Torso", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Amber", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Ammonite", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Dinosaur Egg", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Dinosaur Track", isDonated: false, games: [.ACGCN]),
-        Fossil(name: "Trilobite", isDonated: false, games: [.ACGCN])
+        Fossil(
+            name: "T. Rex",
+            part: "Skull",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "T. Rex",
+            part: "Torso",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "T. Rex",
+            part: "Tail",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Triceratops",
+            part: "Skull", 
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Triceratops",
+            part: "Torso",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Triceratops",
+            part: "Tail",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Stegosaurus",
+            part: "Skull",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Stegosaurus",
+            part: "Torso",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Stegosaurus",
+            part: "Tail",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Pteranodon",
+            part: "Skull",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Pteranodon",
+            part: "Left Wing",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Pteranodon",
+            part: "Right Wing",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Plesiosaurus",
+            part: "Skull",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Plesiosaurus",
+            part: "Neck",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Plesiosaurus",
+            part: "Torso",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Apatosaurus",
+            part: "Skull",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Apatosaurus",
+            part: "Torso",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Apatosaurus",
+            part: "Tail",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Mammoth",
+            part: "Skull",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Mammoth",
+            part: "Torso",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Amber",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Ammonite",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Dinosaur Egg",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Dinosaur Track",
+            isDonated: false,
+            games: [.ACGCN]
+        ),
+        Fossil(
+            name: "Trilobite",
+            isDonated: false,
+            games: [.ACGCN]
+        )
     ]
 }

--- a/AnimalCrossingGCN-Tracker/Models/Fossil.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Fossil.swift
@@ -9,16 +9,24 @@ import SwiftUI
 class Fossil {
     @Attribute(.unique) var id: UUID
     var name: String
-    var part: String?
     var isDonated: Bool
-    var games: [ACGame]
+    var gameRawValues: [String]  // New storage property
+    
+    // Computed property for games
+    var games: [ACGame] {
+        get {
+            gameRawValues.compactMap { ACGame(rawValue: $0) }
+        }
+        set {
+            gameRawValues = newValue.map { $0.rawValue }
+        }
+    }
 
-    init(name: String, part: String? = nil, isDonated: Bool = false, games: [ACGame]) {
+    init(name: String, isDonated: Bool = false, games: [ACGame]) {
         self.id = UUID()
         self.name = name
-        self.part = part
         self.isDonated = isDonated
-        self.games = games
+        self.gameRawValues = games.map { $0.rawValue }
     }
 }
 

--- a/AnimalCrossingGCN-Tracker/Models/Fossil.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Fossil.swift
@@ -9,6 +9,7 @@ import SwiftUI
 class Fossil {
     @Attribute(.unique) var id: UUID
     var name: String
+    var part: String?
     var isDonated: Bool
     var gameRawValues: [String]  // New storage property
     
@@ -22,14 +23,14 @@ class Fossil {
         }
     }
 
-    init(name: String, isDonated: Bool = false, games: [ACGame]) {
+    init(name: String, part: String? = nil, isDonated: Bool = false, games: [ACGame]) {
         self.id = UUID()
         self.name = name
+        self.part = part
         self.isDonated = isDonated
         self.gameRawValues = games.map { $0.rawValue }
     }
 }
-
 struct FossilDetailView: View {
     var fossil: Fossil
 

--- a/AnimalCrossingGCN-Tracker/Models/Fossil.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Fossil.swift
@@ -11,12 +11,14 @@ class Fossil {
     var name: String
     var part: String?
     var isDonated: Bool
+    var games: [ACGame]
 
-    init(name: String, part: String? = nil, isDonated: Bool = false) {
+    init(name: String, part: String? = nil, isDonated: Bool = false, games: [ACGame]) {
         self.id = UUID()
         self.name = name
         self.part = part
         self.isDonated = isDonated
+        self.games = games
     }
 }
 
@@ -25,7 +27,6 @@ struct FossilDetailView: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-        
             if let part = fossil.part {
                 Text("Part: \(part)")
                     .font(.title2)
@@ -39,38 +40,39 @@ struct FossilDetailView: View {
             ))
             .padding(.top)
 
-            Spacer()  // Add some space for layout
+            Spacer()
         }
         .padding()
         .navigationTitle(fossil.name)
     }
 }
+
 func getDefaultFossils() -> [Fossil] {
     return [
-        Fossil(name: "T. Rex", part: "Skull", isDonated: false),
-        Fossil(name: "T. Rex", part: "Torso", isDonated: false),
-        Fossil(name: "T. Rex", part: "Tail", isDonated: false),
-        Fossil(name: "Triceratops", part: "Skull", isDonated: false),
-        Fossil(name: "Triceratops", part: "Torso", isDonated: false),
-        Fossil(name: "Triceratops", part: "Tail", isDonated: false),
-        Fossil(name: "Stegosaurus", part: "Skull", isDonated: false),
-        Fossil(name: "Stegosaurus", part: "Torso", isDonated: false),
-        Fossil(name: "Stegosaurus", part: "Tail", isDonated: false),
-        Fossil(name: "Pteranodon", part: "Skull", isDonated: false),
-        Fossil(name: "Pteranodon", part: "Left Wing", isDonated: false),
-        Fossil(name: "Pteranodon", part: "Right Wing", isDonated: false),
-        Fossil(name: "Plesiosaurus", part: "Skull", isDonated: false),
-        Fossil(name: "Plesiosaurus", part: "Neck", isDonated: false),
-        Fossil(name: "Plesiosaurus", part: "Torso", isDonated: false),
-        Fossil(name: "Apatosaurus", part: "Skull", isDonated: false),
-        Fossil(name: "Apatosaurus", part: "Torso", isDonated: false),
-        Fossil(name: "Apatosaurus", part: "Tail", isDonated: false),
-        Fossil(name: "Mammoth", part: "Skull", isDonated: false),
-        Fossil(name: "Mammoth", part: "Torso", isDonated: false),
-        Fossil(name: "Amber", isDonated: false),
-        Fossil(name: "Ammonite", isDonated: false),
-        Fossil(name: "Dinosaur Egg", isDonated: false),
-        Fossil(name: "Dinosaur Track", isDonated: false),
-        Fossil(name: "Trilobite", isDonated: false)
+        Fossil(name: "T. Rex", part: "Skull", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "T. Rex", part: "Torso", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "T. Rex", part: "Tail", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Triceratops", part: "Skull", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Triceratops", part: "Torso", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Triceratops", part: "Tail", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Stegosaurus", part: "Skull", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Stegosaurus", part: "Torso", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Stegosaurus", part: "Tail", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Pteranodon", part: "Skull", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Pteranodon", part: "Left Wing", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Pteranodon", part: "Right Wing", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Plesiosaurus", part: "Skull", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Plesiosaurus", part: "Neck", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Plesiosaurus", part: "Torso", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Apatosaurus", part: "Skull", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Apatosaurus", part: "Torso", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Apatosaurus", part: "Tail", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Mammoth", part: "Skull", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Mammoth", part: "Torso", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Amber", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Ammonite", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Dinosaur Egg", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Dinosaur Track", isDonated: false, games: [.ACGCN]),
+        Fossil(name: "Trilobite", isDonated: false, games: [.ACGCN])
     ]
 }

--- a/AnimalCrossingGCN-Tracker/Models/Games.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Games.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftData
+
+enum ACGame: String, CaseIterable, Codable {
+    case ACGCN = "Animal Crossing GameCube"
+    case ACWW = "Animal Crossing: Wild World"
+    case ACCF = "Animal Crossing: City Folk"
+    case ACNL = "Animal Crossing: New Leaf"
+    case ACNH = "Animal Crossing: New Horizons"
+    
+    var shortName: String {
+        return String(describing: self)
+    }
+    
+    var icon: String {
+        switch self {
+        case .ACGCN: return "gamecube"
+        case .ACWW: return "ds"
+        case .ACCF: return "wii"
+        case .ACNL: return "3ds"
+        case .ACNH: return "switch"
+        }
+    }
+    
+    var releaseYear: Int {
+        switch self {
+        case .ACGCN: return 2001
+        case .ACWW: return 2005
+        case .ACCF: return 2008
+        case .ACNL: return 2012
+        case .ACNH: return 2020
+        }
+    }
+}

--- a/AnimalCrossingGCN-Tracker/Models/Item.swift
+++ b/AnimalCrossingGCN-Tracker/Models/Item.swift
@@ -9,11 +9,11 @@ import Foundation
 import SwiftUI
 import SwiftData
 
-/*protocol for collectible item, previously in contentview.swift*/
 protocol CollectibleItem: Identifiable, Hashable {
     var id: UUID { get }
     var name: String { get }
     var isDonated: Bool { get set }
+    var games: [ACGame] { get set }
 }
 
 @Model


### PR DESCRIPTION
The codebase now supports items from all five animal crossing games, using an enum for the games in a dedicated Games.swift file. This is just a foundation for future updates! I decided it makes more sense for this to be a fully featured app, which shouldn't just be for the gamecube version. I think I will add a game selector, or a Will be updating the items next.